### PR TITLE
First level optimizations

### DIFF
--- a/scattersphere-core/src/main/scala/com/scattersphere/core/util/RunnableTask.scala
+++ b/scattersphere-core/src/main/scala/com/scattersphere/core/util/RunnableTask.scala
@@ -16,7 +16,7 @@ package com.scattersphere.core.util
 /**
   * RunnableTask class
   *
-  * This class extends the Runnable class, of which you must override the run() method.  The [[RunnableTask
+  * This class extends the Runnable class, of which you must override the run() method.  The [[RunnableTask]]
   * class adds an additional method that can be overridden, which will be called when the run() method completes
   * without any exceptions.
   */

--- a/scattersphere-core/src/main/scala/com/scattersphere/core/util/Task.scala
+++ b/scattersphere-core/src/main/scala/com/scattersphere/core/util/Task.scala
@@ -29,7 +29,7 @@ import scala.collection.mutable.ListBuffer
 case class Task(name: String, task: RunnableTask, async: Boolean = false) {
 
   lazy private val dependencies: ListBuffer[Task] = new ListBuffer[Task]
-  private var taskStatus = TaskStatus.QUEUED
+  private var taskStatus: TaskStatus = TaskQueued
 
   /**
     * Adds a dependent task that is required to complete before this task starts.  This can be multiple tasks, not
@@ -56,27 +56,22 @@ case class Task(name: String, task: RunnableTask, async: Boolean = false) {
   /**
     * Sets the status for this task.
     *
-    * @param status The [[TaskStatus.Value]] to set
+    * @param status The [[TaskStatus]] to set
     */
-  def setStatus(status: TaskStatus.Value) = taskStatus = status
+  def setStatus(status: TaskStatus) = taskStatus = status
 
   /**
     * Returns the current task status.
     *
-    * @return [[TaskStatus.Value]] containing the task status.
+    * @return [[TaskStatus]] containing the task status.
     */
-  def getStatus: TaskStatus.Value = taskStatus
+  def getStatus: TaskStatus = taskStatus
 
   override def toString: String = s"Task{name=$name,status=$taskStatus,dependencies=${dependencies.length}}"
 
 }
 
-/**
-  * This is an enumerator that describes the current status of a task.
-  */
-object TaskStatus extends Enumeration {
-
-  val TaskStatus = Value
-  val QUEUED, RUNNING, FINISHED = Value
-
-}
+sealed trait TaskStatus
+final case object TaskQueued extends TaskStatus
+final case object TaskRunning extends TaskStatus
+final case object TaskFinished extends TaskStatus

--- a/scattersphere-core/src/main/scala/com/scattersphere/core/util/execution/JobExecutor.scala
+++ b/scattersphere-core/src/main/scala/com/scattersphere/core/util/execution/JobExecutor.scala
@@ -15,7 +15,7 @@ package com.scattersphere.core.util.execution
 
 import java.util.concurrent.{CompletableFuture, ExecutorService, Executors}
 
-import com.scattersphere.core.util.{Job, Task, TaskStatus}
+import com.scattersphere.core.util._
 
 import scala.collection.mutable
 
@@ -55,14 +55,14 @@ class JobExecutor(job: Job) {
 
   private def runTask(task: Task): Unit = {
     task.getStatus match {
-      case TaskStatus.QUEUED => {
-        task.setStatus(TaskStatus.RUNNING)
+      case TaskQueued => {
+        task.setStatus(TaskRunning)
         task.task.run()
         task.task.onFinished()
-        task.setStatus(TaskStatus.FINISHED)
+        task.setStatus(TaskFinished)
       }
 
-      case x: TaskStatus.Value => throw new InvalidJobStatusException(task, TaskStatus.QUEUED, x)
+      case x: TaskStatus => throw new InvalidJobStatusException(task, TaskQueued, x)
     }
   }
 
@@ -109,6 +109,6 @@ class JobExecutor(job: Job) {
 }
 
 class InvalidJobStatusException(task: Task,
-                                status: TaskStatus.Value,
-                                expected: TaskStatus.Value)
+                                status: TaskStatus,
+                                expected: TaskStatus)
   extends Exception(s"InvalidJobStatusException: task ${task.name} set to $status, expected $expected")

--- a/scattersphere-core/src/test/scala/com/scattersphere/core/util/ComplicatedJobTest.scala
+++ b/scattersphere-core/src/test/scala/com/scattersphere/core/util/ComplicatedJobTest.scala
@@ -58,9 +58,9 @@ class ComplicatedJobTest extends FlatSpec with Matchers  {
     val task2: Task = new Task("Second Task", runnableTask2, true)
     val task3: Task = new Task("Third Task", runnableTask3, true)
 
-    task1.getStatus shouldBe TaskStatus.QUEUED
-    task2.getStatus shouldBe TaskStatus.QUEUED
-    task3.getStatus shouldBe TaskStatus.QUEUED
+    task1.getStatus shouldBe TaskQueued
+    task2.getStatus shouldBe TaskQueued
+    task3.getStatus shouldBe TaskQueued
 
     task1.name shouldBe "First Task"
     task1.getDependencies.length shouldBe 0
@@ -92,9 +92,9 @@ class ComplicatedJobTest extends FlatSpec with Matchers  {
     runnableTask2.callCount.get() shouldBe 1
     runnableTask3.callCount.get() shouldBe 1
 
-    task1.getStatus shouldBe TaskStatus.FINISHED
-    task2.getStatus shouldBe TaskStatus.FINISHED
-    task3.getStatus shouldBe TaskStatus.FINISHED
+    task1.getStatus shouldBe TaskFinished
+    task2.getStatus shouldBe TaskFinished
+    task3.getStatus shouldBe TaskFinished
   }
 
   /**
@@ -121,10 +121,10 @@ class ComplicatedJobTest extends FlatSpec with Matchers  {
     val task3: Task = new Task("Third Task", runnableTask3, true)
     val task4: Task = new Task("Fourth Task", runnableTask4)
 
-    task1.getStatus shouldBe TaskStatus.QUEUED
-    task2.getStatus shouldBe TaskStatus.QUEUED
-    task3.getStatus shouldBe TaskStatus.QUEUED
-    task4.getStatus shouldBe TaskStatus.QUEUED
+    task1.getStatus shouldBe TaskQueued
+    task2.getStatus shouldBe TaskQueued
+    task3.getStatus shouldBe TaskQueued
+    task4.getStatus shouldBe TaskQueued
 
     task1.name shouldBe "First Task"
     task1.getDependencies.length shouldBe 0
@@ -171,10 +171,10 @@ class ComplicatedJobTest extends FlatSpec with Matchers  {
     runnableTask3.callCount.get() shouldBe 1
     runnableTask4.callCount.get() shouldBe 1
 
-    task1.getStatus shouldBe TaskStatus.FINISHED
-    task2.getStatus shouldBe TaskStatus.FINISHED
-    task3.getStatus shouldBe TaskStatus.FINISHED
-    task4.getStatus shouldBe TaskStatus.FINISHED
+    task1.getStatus shouldBe TaskFinished
+    task2.getStatus shouldBe TaskFinished
+    task3.getStatus shouldBe TaskFinished
+    task4.getStatus shouldBe TaskFinished
   }
 
   /**
@@ -199,12 +199,12 @@ class ComplicatedJobTest extends FlatSpec with Matchers  {
     val task5: Task = new Task("3-B-2-B", runnableTask5, true)
     val task6: Task = new Task("4", runnableTask6)
 
-    task1.getStatus shouldBe TaskStatus.QUEUED
-    task2.getStatus shouldBe TaskStatus.QUEUED
-    task3.getStatus shouldBe TaskStatus.QUEUED
-    task4.getStatus shouldBe TaskStatus.QUEUED
-    task5.getStatus shouldBe TaskStatus.QUEUED
-    task6.getStatus shouldBe TaskStatus.QUEUED
+    task1.getStatus shouldBe TaskQueued
+    task2.getStatus shouldBe TaskQueued
+    task3.getStatus shouldBe TaskQueued
+    task4.getStatus shouldBe TaskQueued
+    task5.getStatus shouldBe TaskQueued
+    task6.getStatus shouldBe TaskQueued
 
     task1.name shouldBe "1"
     task1.getDependencies.length shouldBe 0
@@ -270,12 +270,12 @@ class ComplicatedJobTest extends FlatSpec with Matchers  {
     runnableTask5.callCount.get() shouldBe 1
     runnableTask6.callCount.get() shouldBe 1
 
-    task1.getStatus shouldBe TaskStatus.FINISHED
-    task2.getStatus shouldBe TaskStatus.FINISHED
-    task3.getStatus shouldBe TaskStatus.FINISHED
-    task4.getStatus shouldBe TaskStatus.FINISHED
-    task5.getStatus shouldBe TaskStatus.FINISHED
-    task6.getStatus shouldBe TaskStatus.FINISHED
+    task1.getStatus shouldBe TaskFinished
+    task2.getStatus shouldBe TaskFinished
+    task3.getStatus shouldBe TaskFinished
+    task4.getStatus shouldBe TaskFinished
+    task5.getStatus shouldBe TaskFinished
+    task6.getStatus shouldBe TaskFinished
   }
 
 }

--- a/scattersphere-core/src/test/scala/com/scattersphere/core/util/SimpleJobTest.scala
+++ b/scattersphere-core/src/test/scala/com/scattersphere/core/util/SimpleJobTest.scala
@@ -64,9 +64,9 @@ class SimpleJobTest extends FlatSpec with Matchers  {
     val task2: Task = new Task("Second Runnable Task", runnableTask2)
     val task3: Task = new Task("Third Runnable Task", runnableTask3)
 
-    task1.getStatus shouldBe TaskStatus.QUEUED
-    task2.getStatus shouldBe TaskStatus.QUEUED
-    task3.getStatus shouldBe TaskStatus.QUEUED
+    task1.getStatus shouldBe TaskQueued
+    task2.getStatus shouldBe TaskQueued
+    task3.getStatus shouldBe TaskQueued
 
     task1.name shouldBe "First Runnable Task"
     task1.getDependencies.length shouldBe 0
@@ -94,9 +94,9 @@ class SimpleJobTest extends FlatSpec with Matchers  {
     runnableTask1.setVar shouldBe 1
     runnableTask2.setVar shouldBe 2
     runnableTask3.setVar shouldBe 3
-    task1.getStatus shouldBe TaskStatus.FINISHED
-    task2.getStatus shouldBe TaskStatus.FINISHED
-    task3.getStatus shouldBe TaskStatus.FINISHED
+    task1.getStatus shouldBe TaskFinished
+    task2.getStatus shouldBe TaskFinished
+    task3.getStatus shouldBe TaskFinished
   }
 
   /**
@@ -111,9 +111,9 @@ class SimpleJobTest extends FlatSpec with Matchers  {
     val task2: Task = new Task("Second Runnable Task", runnableTask2)
     val task3: Task = new Task("Third Runnable Task", runnableTask3)
 
-    task1.getStatus shouldBe TaskStatus.QUEUED
-    task2.getStatus shouldBe TaskStatus.QUEUED
-    task3.getStatus shouldBe TaskStatus.QUEUED
+    task1.getStatus shouldBe TaskQueued
+    task2.getStatus shouldBe TaskQueued
+    task3.getStatus shouldBe TaskQueued
 
     task1.name shouldBe "First Runnable Task"
     task1.getDependencies.length shouldBe 0
@@ -131,16 +131,16 @@ class SimpleJobTest extends FlatSpec with Matchers  {
     runnableTask1.setVar shouldBe 1
     runnableTask2.setVar shouldBe 2
     runnableTask3.setVar shouldBe 3
-    task1.getStatus shouldBe TaskStatus.FINISHED
-    task2.getStatus shouldBe TaskStatus.FINISHED
-    task3.getStatus shouldBe TaskStatus.FINISHED
+    task1.getStatus shouldBe TaskFinished
+    task2.getStatus shouldBe TaskFinished
+    task3.getStatus shouldBe TaskFinished
   }
 
   it should "not allow the same task to exist on two separate jobs after completing in one job" in {
     val runnableTask1 = new RunnableTestTask("1")
     val task1: Task = new Task("First Runnable Task", runnableTask1)
 
-    task1.getStatus shouldBe TaskStatus.QUEUED
+    task1.getStatus shouldBe TaskQueued
     task1.name shouldBe "First Runnable Task"
     task1.getDependencies.length shouldBe 0
     val job1: Job = new Job("Test", Seq(task1))
@@ -148,7 +148,7 @@ class SimpleJobTest extends FlatSpec with Matchers  {
 
     jobExec.queue().join()
     runnableTask1.setVar shouldBe 1
-    task1.getStatus shouldBe TaskStatus.FINISHED
+    task1.getStatus shouldBe TaskFinished
 
     val job2: Job = new Job("Test2", Seq(task1))
     val jobExec2: JobExecutor = new JobExecutor(job2)


### PR DESCRIPTION
Adds exception throwing when a job is expected to run that is not in QUEUED state.  Tests this case in SimpleJobTest.

- Moves the job run task to a single function so that this function can be extended instead of repeated
- Adds an InvalidJobStatusException when trying to run a `Task` that is not in QUEUED state
- Adds a test to make sure that the same `Task` cannot be added to two or more Jobs after completing.

This logic will change slightly after we add the ability to `cancel` a job.