### PR TITLE
Ticket 12

### DIFF
--- a/scattersphere-core/src/main/scala/com/scattersphere/core/util/execution/JobExecutor.scala
+++ b/scattersphere-core/src/main/scala/com/scattersphere/core/util/execution/JobExecutor.scala
@@ -59,19 +59,28 @@ class JobExecutor(job: Job) {
     this
   }
 
-  private def unlock(): Unit = {
-    lockObject.synchronized {
-      lockObject.notifyAll
-    }
-  }
-
+  /**
+    * Triggers the JobExecutor to run the job immediately, returning after the lock for the job has been released.
+    * Use of this behavior will cause the job to run in the background, so logging and other verbose functions could
+    * interfere with output from other functions in your code.
+    */
   def runNonblocking(): Unit = {
     unlock
   }
 
+  /**
+    * Triggers the JobExecutor to run the job, but blocks all further execution until the job has completed.  This
+    * function will return after the job completes.
+    */
   def runBlocking(): Unit = {
     unlock
     completableFuture.join
+  }
+
+  private def unlock(): Unit = {
+    lockObject.synchronized {
+      lockObject.notifyAll
+    }
   }
 
   private def runTask(task: Task): Unit = {

--- a/scattersphere-core/src/test/scala/com/scattersphere/core/util/ComplicatedJobTest.scala
+++ b/scattersphere-core/src/test/scala/com/scattersphere/core/util/ComplicatedJobTest.scala
@@ -84,7 +84,7 @@ class ComplicatedJobTest extends FlatSpec with Matchers  {
     runnableTask2.setVar shouldBe ""
     runnableTask3.setVar shouldBe ""
 
-    jobExec.queue().join()
+    jobExec.queue().runBlocking()
     runnableTask1.setVar shouldBe "1"
     runnableTask2.setVar shouldBe "2-A"
     runnableTask3.setVar shouldBe "2-B"
@@ -158,7 +158,7 @@ class ComplicatedJobTest extends FlatSpec with Matchers  {
     runnableTask3.setVar shouldBe ""
     runnableTask4.setVar shouldBe ""
 
-    jobExec.queue().join()
+    jobExec.queue().runBlocking()
     runnableTask1.setVar shouldBe "1"
     runnableTask2.setVar shouldBe "2-A"
     runnableTask3.setVar shouldBe "2-B"
@@ -253,7 +253,7 @@ class ComplicatedJobTest extends FlatSpec with Matchers  {
     runnableTask5.setVar shouldBe ""
     runnableTask6.setVar shouldBe ""
 
-    jobExec.queue().join()
+    jobExec.queue().runBlocking()
     runnableTask1.setVar shouldBe "1"
     runnableTask2.setVar shouldBe "2-A"
     runnableTask3.setVar shouldBe "2-B"

--- a/scattersphere-core/src/test/scala/com/scattersphere/core/util/ExceptionJobTest.scala
+++ b/scattersphere-core/src/test/scala/com/scattersphere/core/util/ExceptionJobTest.scala
@@ -1,11 +1,9 @@
 package com.scattersphere.core.util
 
-import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
 
 import com.scattersphere.core.util.execution.JobExecutor
 import org.scalatest.{FlatSpec, Matchers}
-
-import scala.concurrent.ExecutionException
 
 class ExceptionJobTest extends FlatSpec with Matchers {
 
@@ -31,13 +29,15 @@ class ExceptionJobTest extends FlatSpec with Matchers {
     job1.tasks.length shouldBe 1
     job1.tasks(0) shouldBe task1
 
-    val queuedJob: CompletableFuture[Void] = jobExec.queue()
+    val queuedJob: JobExecutor = jobExec.queue()
+
+    queuedJob.runNonblocking()
 
     println("Waiting 5 seconds before submitting a cancel.")
     Thread.sleep(5000)
 
-    assertThrows[ExecutionException] {
-      queuedJob.get()
+    assertThrows[CompletionException] {
+      queuedJob.runBlocking()
     }
 
     task1.getStatus match {

--- a/scattersphere-core/src/test/scala/com/scattersphere/core/util/SimpleJobTest.scala
+++ b/scattersphere-core/src/test/scala/com/scattersphere/core/util/SimpleJobTest.scala
@@ -90,7 +90,7 @@ class SimpleJobTest extends FlatSpec with Matchers  {
     runnableTask2.setVar shouldBe 0
     runnableTask3.setVar shouldBe 0
 
-    jobExec.queue().join()
+    jobExec.queue().runBlocking()
     runnableTask1.setVar shouldBe 1
     runnableTask2.setVar shouldBe 2
     runnableTask3.setVar shouldBe 3
@@ -127,7 +127,7 @@ class SimpleJobTest extends FlatSpec with Matchers  {
     val job1: Job = new Job("Test", Seq(task1, task2, task3))
     val jobExec: JobExecutor = new JobExecutor(job1)
 
-    jobExec.queue().join()
+    jobExec.queue().runBlocking()
     runnableTask1.setVar shouldBe 1
     runnableTask2.setVar shouldBe 2
     runnableTask3.setVar shouldBe 3
@@ -146,7 +146,7 @@ class SimpleJobTest extends FlatSpec with Matchers  {
     val job1: Job = new Job("Test", Seq(task1))
     val jobExec: JobExecutor = new JobExecutor(job1)
 
-    jobExec.queue().join()
+    jobExec.queue().runBlocking()
     runnableTask1.setVar shouldBe 1
     task1.getStatus shouldBe TaskFinished
 
@@ -155,7 +155,7 @@ class SimpleJobTest extends FlatSpec with Matchers  {
 
     // This will be upgraded soon so that the underlying cause can be pulled from the Job, but only if the job
     // completes exceptionally.
-    jobExec2.queue().join()
+    jobExec2.queue().runBlocking()
 
     task1.getStatus match {
       case TaskFailed(reason) => reason match {


### PR DESCRIPTION
This code adds the following changes:

- Root tasks block on a lock to be released when a `run` call is made (this way, tasks aren't just free-flowing.)
- Added `runBlocking` and `runNonblocking` to allow for the ability to block or not.
- Updated all tests to make sure the code still produced results as expected.