### PR TITLE
Cleanup 2

### DIFF
--- a/scattersphere-core/src/main/scala/com/scattersphere/core/util/Job.scala
+++ b/scattersphere-core/src/main/scala/com/scattersphere/core/util/Job.scala
@@ -28,7 +28,7 @@ case class Job(name: String, tasks: Seq[Task]) {
 
   def setStatus(status: JobStatus): Unit = jobStatus = status
 
-  def getStatus(): JobStatus = jobStatus
+  def status(): JobStatus = jobStatus
 
   override def toString = s"Job{name=$name,jobStatus=$jobStatus,tasks=$tasks}"
 

--- a/scattersphere-core/src/main/scala/com/scattersphere/core/util/Task.scala
+++ b/scattersphere-core/src/main/scala/com/scattersphere/core/util/Task.scala
@@ -28,7 +28,7 @@ import scala.collection.mutable.ListBuffer
   */
 case class Task(name: String, task: RunnableTask, async: Boolean = false) {
 
-  lazy private val dependencies: ListBuffer[Task] = new ListBuffer[Task]
+  lazy private val deps: ListBuffer[Task] = new ListBuffer[Task]
   private var taskStatus: TaskStatus = TaskQueued
 
   /**
@@ -43,7 +43,7 @@ case class Task(name: String, task: RunnableTask, async: Boolean = false) {
       throw new IllegalArgumentException("Unable to add task: task is self")
     }
 
-    dependencies += task
+    deps += task
   }
 
   /**
@@ -51,7 +51,7 @@ case class Task(name: String, task: RunnableTask, async: Boolean = false) {
     *
     * @return Seq containing [[Task]] dependency list.
     */
-  def getDependencies: Seq[Task] = dependencies
+  def dependencies(): Seq[Task] = deps
 
   /**
     * Sets the status for this task.
@@ -65,9 +65,9 @@ case class Task(name: String, task: RunnableTask, async: Boolean = false) {
     *
     * @return [[TaskStatus]] containing the task status.
     */
-  def getStatus: TaskStatus = taskStatus
+  def status(): TaskStatus = taskStatus
 
-  override def toString: String = s"Task{name=$name,status=$taskStatus,dependencies=${dependencies.length}}"
+  override def toString: String = s"Task{name=$name,status=$taskStatus,dependencies=${deps.length}}"
 
 }
 

--- a/scattersphere-core/src/test/scala/com/scattersphere/core/util/ComplicatedJobTest.scala
+++ b/scattersphere-core/src/test/scala/com/scattersphere/core/util/ComplicatedJobTest.scala
@@ -58,20 +58,20 @@ class ComplicatedJobTest extends FlatSpec with Matchers  {
     val task2: Task = new Task("Second Task", runnableTask2, true)
     val task3: Task = new Task("Third Task", runnableTask3, true)
 
-    task1.getStatus shouldBe TaskQueued
-    task2.getStatus shouldBe TaskQueued
-    task3.getStatus shouldBe TaskQueued
+    task1.status shouldBe TaskQueued
+    task2.status shouldBe TaskQueued
+    task3.status shouldBe TaskQueued
 
     task1.name shouldBe "First Task"
-    task1.getDependencies.length shouldBe 0
+    task1.dependencies.length shouldBe 0
 
     task2.name shouldBe "Second Task"
     task2.addDependency(task1)
-    task2.getDependencies.length shouldBe 1
+    task2.dependencies.length shouldBe 1
 
     task3.name shouldBe "Third Task"
     task3.addDependency(task1)
-    task3.getDependencies.length shouldBe 1
+    task3.dependencies.length shouldBe 1
 
     val job1: Job = new Job("Test", Seq(task1, task2, task3))
     val jobExec: JobExecutor = new JobExecutor(job1)
@@ -84,10 +84,10 @@ class ComplicatedJobTest extends FlatSpec with Matchers  {
     runnableTask2.setVar shouldBe ""
     runnableTask3.setVar shouldBe ""
 
-    job1.getStatus() shouldBe JobQueued
+    job1.status() shouldBe JobQueued
     jobExec.isBlocking() shouldBe true
     jobExec.queue().run()
-    job1.getStatus() shouldBe JobFinished
+    job1.status() shouldBe JobFinished
 
     runnableTask1.setVar shouldBe "1"
     runnableTask2.setVar shouldBe "2-A"
@@ -96,9 +96,9 @@ class ComplicatedJobTest extends FlatSpec with Matchers  {
     runnableTask2.callCount.get() shouldBe 1
     runnableTask3.callCount.get() shouldBe 1
 
-    task1.getStatus shouldBe TaskFinished
-    task2.getStatus shouldBe TaskFinished
-    task3.getStatus shouldBe TaskFinished
+    task1.status shouldBe TaskFinished
+    task2.status shouldBe TaskFinished
+    task3.status shouldBe TaskFinished
   }
 
   /**
@@ -125,29 +125,29 @@ class ComplicatedJobTest extends FlatSpec with Matchers  {
     val task3: Task = new Task("Third Task", runnableTask3, true)
     val task4: Task = new Task("Fourth Task", runnableTask4)
 
-    task1.getStatus shouldBe TaskQueued
-    task2.getStatus shouldBe TaskQueued
-    task3.getStatus shouldBe TaskQueued
-    task4.getStatus shouldBe TaskQueued
+    task1.status shouldBe TaskQueued
+    task2.status shouldBe TaskQueued
+    task3.status shouldBe TaskQueued
+    task4.status shouldBe TaskQueued
 
     task1.name shouldBe "First Task"
-    task1.getDependencies.length shouldBe 0
+    task1.dependencies.length shouldBe 0
 
     // Task 2 requires task 1 to finish before starting.
     task2.name shouldBe "Second Task"
     task2.addDependency(task1)
-    task2.getDependencies.length shouldBe 1
+    task2.dependencies.length shouldBe 1
 
     // Task 3 requires task 1 to finish before starting.
     task3.name shouldBe "Third Task"
     task3.addDependency(task1)
-    task3.getDependencies.length shouldBe 1
+    task3.dependencies.length shouldBe 1
 
     // Task 4 requires task 2 and task 3 to finish before starting.
     task4.name shouldBe "Fourth Task"
     task4.addDependency(task2)
     task4.addDependency(task3)
-    task4.getDependencies.length shouldBe 2
+    task4.dependencies.length shouldBe 2
 
     val job1: Job = new Job("Test", Seq(task1, task2, task3, task4))
     val jobExec: JobExecutor = new JobExecutor(job1)
@@ -162,10 +162,10 @@ class ComplicatedJobTest extends FlatSpec with Matchers  {
     runnableTask3.setVar shouldBe ""
     runnableTask4.setVar shouldBe ""
 
-    job1.getStatus() shouldBe JobQueued
+    job1.status() shouldBe JobQueued
     jobExec.isBlocking() shouldBe true
     jobExec.queue().run()
-    job1.getStatus() shouldBe JobFinished
+    job1.status() shouldBe JobFinished
 
     runnableTask1.setVar shouldBe "1"
     runnableTask2.setVar shouldBe "2-A"
@@ -179,10 +179,10 @@ class ComplicatedJobTest extends FlatSpec with Matchers  {
     runnableTask3.callCount.get() shouldBe 1
     runnableTask4.callCount.get() shouldBe 1
 
-    task1.getStatus shouldBe TaskFinished
-    task2.getStatus shouldBe TaskFinished
-    task3.getStatus shouldBe TaskFinished
-    task4.getStatus shouldBe TaskFinished
+    task1.status shouldBe TaskFinished
+    task2.status shouldBe TaskFinished
+    task3.status shouldBe TaskFinished
+    task4.status shouldBe TaskFinished
   }
 
   /**
@@ -207,42 +207,42 @@ class ComplicatedJobTest extends FlatSpec with Matchers  {
     val task5: Task = new Task("3-B-2-B", runnableTask5, true)
     val task6: Task = new Task("4", runnableTask6)
 
-    task1.getStatus shouldBe TaskQueued
-    task2.getStatus shouldBe TaskQueued
-    task3.getStatus shouldBe TaskQueued
-    task4.getStatus shouldBe TaskQueued
-    task5.getStatus shouldBe TaskQueued
-    task6.getStatus shouldBe TaskQueued
+    task1.status shouldBe TaskQueued
+    task2.status shouldBe TaskQueued
+    task3.status shouldBe TaskQueued
+    task4.status shouldBe TaskQueued
+    task5.status shouldBe TaskQueued
+    task6.status shouldBe TaskQueued
 
     task1.name shouldBe "1"
-    task1.getDependencies.length shouldBe 0
+    task1.dependencies.length shouldBe 0
 
     // Task 2-A starts after 1 completes.
     task2.name shouldBe "2-A"
     task2.addDependency(task1)
-    task2.getDependencies.length shouldBe 1
+    task2.dependencies.length shouldBe 1
 
     // Task 2-B starts after 1 completes.
     task3.name shouldBe "2-B"
     task3.addDependency(task1)
-    task3.getDependencies.length shouldBe 1
+    task3.dependencies.length shouldBe 1
 
     // Task 3-A asynchronously starts after 2-B completes
     task4.name shouldBe "3-A-2-B"
     task4.addDependency(task3)
-    task4.getDependencies.length shouldBe 1
+    task4.dependencies.length shouldBe 1
 
     // Task 3-B asynchronously starts after 2-B completes
     task5.name shouldBe "3-B-2-B"
     task5.addDependency(task3)
-    task5.getDependencies.length shouldBe 1
+    task5.dependencies.length shouldBe 1
 
     // Task 4 starts after 2-A, 3-A and 3-B complete.
     task6.name shouldBe "4"
     task6.addDependency(task2)
     task6.addDependency(task4)
     task6.addDependency(task5)
-    task6.getDependencies.length shouldBe 3
+    task6.dependencies.length shouldBe 3
 
     val job1: Job = new Job("Test", Seq(task1, task2, task3, task4, task5, task6))
     val jobExec: JobExecutor = new JobExecutor(job1)
@@ -261,10 +261,10 @@ class ComplicatedJobTest extends FlatSpec with Matchers  {
     runnableTask5.setVar shouldBe ""
     runnableTask6.setVar shouldBe ""
 
-    job1.getStatus() shouldBe JobQueued
+    job1.status() shouldBe JobQueued
     jobExec.isBlocking() shouldBe true
     jobExec.queue().run()
-    job1.getStatus() shouldBe JobFinished
+    job1.status() shouldBe JobFinished
 
     runnableTask1.setVar shouldBe "1"
     runnableTask2.setVar shouldBe "2-A"
@@ -282,12 +282,12 @@ class ComplicatedJobTest extends FlatSpec with Matchers  {
     runnableTask5.callCount.get() shouldBe 1
     runnableTask6.callCount.get() shouldBe 1
 
-    task1.getStatus shouldBe TaskFinished
-    task2.getStatus shouldBe TaskFinished
-    task3.getStatus shouldBe TaskFinished
-    task4.getStatus shouldBe TaskFinished
-    task5.getStatus shouldBe TaskFinished
-    task6.getStatus shouldBe TaskFinished
+    task1.status shouldBe TaskFinished
+    task2.status shouldBe TaskFinished
+    task3.status shouldBe TaskFinished
+    task4.status shouldBe TaskFinished
+    task5.status shouldBe TaskFinished
+    task6.status shouldBe TaskFinished
   }
 
 }

--- a/scattersphere-core/src/test/scala/com/scattersphere/core/util/ComplicatedJobTest.scala
+++ b/scattersphere-core/src/test/scala/com/scattersphere/core/util/ComplicatedJobTest.scala
@@ -85,6 +85,7 @@ class ComplicatedJobTest extends FlatSpec with Matchers  {
     runnableTask3.setVar shouldBe ""
 
     job1.getStatus() shouldBe JobQueued
+    jobExec.isBlocking() shouldBe true
     jobExec.queue().run()
     job1.getStatus() shouldBe JobFinished
 
@@ -162,6 +163,7 @@ class ComplicatedJobTest extends FlatSpec with Matchers  {
     runnableTask4.setVar shouldBe ""
 
     job1.getStatus() shouldBe JobQueued
+    jobExec.isBlocking() shouldBe true
     jobExec.queue().run()
     job1.getStatus() shouldBe JobFinished
 
@@ -260,6 +262,7 @@ class ComplicatedJobTest extends FlatSpec with Matchers  {
     runnableTask6.setVar shouldBe ""
 
     job1.getStatus() shouldBe JobQueued
+    jobExec.isBlocking() shouldBe true
     jobExec.queue().run()
     job1.getStatus() shouldBe JobFinished
 

--- a/scattersphere-core/src/test/scala/com/scattersphere/core/util/ComplicatedJobTest.scala
+++ b/scattersphere-core/src/test/scala/com/scattersphere/core/util/ComplicatedJobTest.scala
@@ -85,7 +85,7 @@ class ComplicatedJobTest extends FlatSpec with Matchers  {
     runnableTask3.setVar shouldBe ""
 
     job1.getStatus() shouldBe JobQueued
-    jobExec.queue().runBlocking()
+    jobExec.queue().run()
     job1.getStatus() shouldBe JobFinished
 
     runnableTask1.setVar shouldBe "1"
@@ -162,7 +162,7 @@ class ComplicatedJobTest extends FlatSpec with Matchers  {
     runnableTask4.setVar shouldBe ""
 
     job1.getStatus() shouldBe JobQueued
-    jobExec.queue().runBlocking()
+    jobExec.queue().run()
     job1.getStatus() shouldBe JobFinished
 
     runnableTask1.setVar shouldBe "1"
@@ -260,7 +260,7 @@ class ComplicatedJobTest extends FlatSpec with Matchers  {
     runnableTask6.setVar shouldBe ""
 
     job1.getStatus() shouldBe JobQueued
-    jobExec.queue().runBlocking()
+    jobExec.queue().run()
     job1.getStatus() shouldBe JobFinished
 
     runnableTask1.setVar shouldBe "1"

--- a/scattersphere-core/src/test/scala/com/scattersphere/core/util/ExceptionJobTest.scala
+++ b/scattersphere-core/src/test/scala/com/scattersphere/core/util/ExceptionJobTest.scala
@@ -32,7 +32,9 @@ class ExceptionJobTest extends FlatSpec with Matchers {
 
     val queuedJob: JobExecutor = jobExec.queue()
 
-    queuedJob.runNonblocking()
+    queuedJob.setBlocking(false)
+    queuedJob.run()
+    queuedJob.setBlocking(true)
     job1.getStatus() shouldBe JobRunning
 
     println("Waiting 5 seconds before submitting a cancel.")
@@ -43,7 +45,7 @@ class ExceptionJobTest extends FlatSpec with Matchers {
     }
 
     assertThrows[CompletionException] {
-      queuedJob.runBlocking()
+      queuedJob.run()
     }
 
     task1.getStatus match {

--- a/scattersphere-core/src/test/scala/com/scattersphere/core/util/ExceptionJobTest.scala
+++ b/scattersphere-core/src/test/scala/com/scattersphere/core/util/ExceptionJobTest.scala
@@ -19,16 +19,16 @@ class ExceptionJobTest extends FlatSpec with Matchers {
     val runnableTask1: RunnableTask = new TimerJob(3)
     val task1: Task = new Task("3 second task", runnableTask1)
 
-    task1.getStatus shouldBe TaskQueued
+    task1.status shouldBe TaskQueued
     task1.name shouldBe "3 second task"
-    task1.getDependencies.length shouldBe 0
+    task1.dependencies.length shouldBe 0
 
     val job1: Job = new Job("Cancelable Job", Seq(task1))
     val jobExec: JobExecutor = new JobExecutor(job1)
 
     job1.tasks.length shouldBe 1
     job1.tasks(0) shouldBe task1
-    job1.getStatus() shouldBe JobQueued
+    job1.status() shouldBe JobQueued
 
     val queuedJob: JobExecutor = jobExec.queue()
 
@@ -36,11 +36,11 @@ class ExceptionJobTest extends FlatSpec with Matchers {
     jobExec.isBlocking() shouldBe false
     queuedJob.run()
     queuedJob.setBlocking(true)
-    job1.getStatus() shouldBe JobRunning
+    job1.status() shouldBe JobRunning
 
     println("Waiting 5 seconds before submitting a cancel.")
     Thread.sleep(5000)
-    job1.getStatus() match {
+    job1.status() match {
       case JobFailed(_) => println("Job failed expected.")
       case x => fail(s"Unexpected job state caught: $x")
     }
@@ -51,7 +51,7 @@ class ExceptionJobTest extends FlatSpec with Matchers {
       queuedJob.run()
     }
 
-    task1.getStatus match {
+    task1.status match {
       case TaskFailed(reason) => reason match {
         case _: NullPointerException => println(s"Expected NullPointerException caught.")
         case x => fail(s"Unexpected exception $x caught.")

--- a/scattersphere-core/src/test/scala/com/scattersphere/core/util/ExceptionJobTest.scala
+++ b/scattersphere-core/src/test/scala/com/scattersphere/core/util/ExceptionJobTest.scala
@@ -33,6 +33,7 @@ class ExceptionJobTest extends FlatSpec with Matchers {
     val queuedJob: JobExecutor = jobExec.queue()
 
     queuedJob.setBlocking(false)
+    jobExec.isBlocking() shouldBe false
     queuedJob.run()
     queuedJob.setBlocking(true)
     job1.getStatus() shouldBe JobRunning
@@ -43,6 +44,8 @@ class ExceptionJobTest extends FlatSpec with Matchers {
       case JobFailed(_) => println("Job failed expected.")
       case x => fail(s"Unexpected job state caught: $x")
     }
+
+    jobExec.isBlocking() shouldBe true
 
     assertThrows[CompletionException] {
       queuedJob.run()

--- a/scattersphere-core/src/test/scala/com/scattersphere/core/util/SimpleJobTest.scala
+++ b/scattersphere-core/src/test/scala/com/scattersphere/core/util/SimpleJobTest.scala
@@ -64,20 +64,20 @@ class SimpleJobTest extends FlatSpec with Matchers  {
     val task2: Task = new Task("Second Runnable Task", runnableTask2)
     val task3: Task = new Task("Third Runnable Task", runnableTask3)
 
-    task1.getStatus shouldBe TaskQueued
-    task2.getStatus shouldBe TaskQueued
-    task3.getStatus shouldBe TaskQueued
+    task1.status shouldBe TaskQueued
+    task2.status shouldBe TaskQueued
+    task3.status shouldBe TaskQueued
 
     task1.name shouldBe "First Runnable Task"
-    task1.getDependencies.length shouldBe 0
+    task1.dependencies.length shouldBe 0
 
     task2.name shouldBe "Second Runnable Task"
     task2.addDependency(task1)
-    task2.getDependencies.length shouldBe 1
+    task2.dependencies.length shouldBe 1
 
     task3.name shouldBe "Third Runnable Task"
     task3.addDependency(task2)
-    task3.getDependencies.length shouldBe 1
+    task3.dependencies.length shouldBe 1
 
     val job1: Job = new Job("Test", Seq(task1, task2, task3))
     val jobExec: JobExecutor = new JobExecutor(job1)
@@ -90,17 +90,17 @@ class SimpleJobTest extends FlatSpec with Matchers  {
     runnableTask2.setVar shouldBe 0
     runnableTask3.setVar shouldBe 0
 
-    job1.getStatus() shouldBe JobQueued
+    job1.status() shouldBe JobQueued
     jobExec.isBlocking() shouldBe true
     jobExec.queue().run()
-    job1.getStatus() shouldBe JobFinished
+    job1.status() shouldBe JobFinished
 
     runnableTask1.setVar shouldBe 1
     runnableTask2.setVar shouldBe 2
     runnableTask3.setVar shouldBe 3
-    task1.getStatus shouldBe TaskFinished
-    task2.getStatus shouldBe TaskFinished
-    task3.getStatus shouldBe TaskFinished
+    task1.status shouldBe TaskFinished
+    task2.status shouldBe TaskFinished
+    task3.status shouldBe TaskFinished
   }
 
   /**
@@ -115,51 +115,51 @@ class SimpleJobTest extends FlatSpec with Matchers  {
     val task2: Task = new Task("Second Runnable Task", runnableTask2)
     val task3: Task = new Task("Third Runnable Task", runnableTask3)
 
-    task1.getStatus shouldBe TaskQueued
-    task2.getStatus shouldBe TaskQueued
-    task3.getStatus shouldBe TaskQueued
+    task1.status shouldBe TaskQueued
+    task2.status shouldBe TaskQueued
+    task3.status shouldBe TaskQueued
 
     task1.name shouldBe "First Runnable Task"
-    task1.getDependencies.length shouldBe 0
+    task1.dependencies.length shouldBe 0
 
     task2.name shouldBe "Second Runnable Task"
-    task2.getDependencies.length shouldBe 0
+    task2.dependencies.length shouldBe 0
 
     task3.name shouldBe "Third Runnable Task"
-    task3.getDependencies.length shouldBe 0
+    task3.dependencies.length shouldBe 0
 
     val job1: Job = new Job("Test", Seq(task1, task2, task3))
     val jobExec: JobExecutor = new JobExecutor(job1)
 
-    job1.getStatus() shouldBe JobQueued
+    job1.status() shouldBe JobQueued
     jobExec.queue().run()
-    job1.getStatus() shouldBe JobFinished
+    job1.status() shouldBe JobFinished
 
     runnableTask1.setVar shouldBe 1
     runnableTask2.setVar shouldBe 2
     runnableTask3.setVar shouldBe 3
-    task1.getStatus shouldBe TaskFinished
-    task2.getStatus shouldBe TaskFinished
-    task3.getStatus shouldBe TaskFinished
+    task1.status shouldBe TaskFinished
+    task2.status shouldBe TaskFinished
+    task3.status shouldBe TaskFinished
   }
 
   it should "not allow the same task to exist on two separate jobs after completing in one job" in {
     val runnableTask1 = new RunnableTestTask("1")
     val task1: Task = new Task("First Runnable Task", runnableTask1)
 
-    task1.getStatus shouldBe TaskQueued
+    task1.status shouldBe TaskQueued
     task1.name shouldBe "First Runnable Task"
-    task1.getDependencies.length shouldBe 0
+    task1.dependencies.length shouldBe 0
     val job1: Job = new Job("Test", Seq(task1))
     val jobExec: JobExecutor = new JobExecutor(job1)
 
-    job1.getStatus() shouldBe JobQueued
+    job1.status() shouldBe JobQueued
     jobExec.isBlocking() shouldBe true
     jobExec.queue().run()
-    job1.getStatus() shouldBe JobFinished
+    job1.status() shouldBe JobFinished
 
     runnableTask1.setVar shouldBe 1
-    task1.getStatus shouldBe TaskFinished
+    task1.status shouldBe TaskFinished
 
     val job2: Job = new Job("Test2", Seq(task1))
     val jobExec2: JobExecutor = new JobExecutor(job2)
@@ -168,12 +168,12 @@ class SimpleJobTest extends FlatSpec with Matchers  {
     // completes exceptionally.
     jobExec2.isBlocking() shouldBe true
     jobExec2.queue().run()
-    job2.getStatus() match {
+    job2.status() match {
       case JobFailed(_) => println("Job failed, expected.")
       case x => fail(s"Unexpected job status: $x")
     }
 
-    task1.getStatus match {
+    task1.status match {
       case TaskFailed(reason) => reason match {
         case _: InvalidTaskStateException => println(s"Expected InvalidTaskStateException caught.")
         case x => fail(s"Unexpected exception $x caught.")

--- a/scattersphere-core/src/test/scala/com/scattersphere/core/util/SimpleJobTest.scala
+++ b/scattersphere-core/src/test/scala/com/scattersphere/core/util/SimpleJobTest.scala
@@ -91,6 +91,7 @@ class SimpleJobTest extends FlatSpec with Matchers  {
     runnableTask3.setVar shouldBe 0
 
     job1.getStatus() shouldBe JobQueued
+    jobExec.isBlocking() shouldBe true
     jobExec.queue().run()
     job1.getStatus() shouldBe JobFinished
 
@@ -153,6 +154,7 @@ class SimpleJobTest extends FlatSpec with Matchers  {
     val jobExec: JobExecutor = new JobExecutor(job1)
 
     job1.getStatus() shouldBe JobQueued
+    jobExec.isBlocking() shouldBe true
     jobExec.queue().run()
     job1.getStatus() shouldBe JobFinished
 
@@ -164,6 +166,7 @@ class SimpleJobTest extends FlatSpec with Matchers  {
 
     // This will be upgraded soon so that the underlying cause can be pulled from the Job, but only if the job
     // completes exceptionally.
+    jobExec2.isBlocking() shouldBe true
     jobExec2.queue().run()
     job2.getStatus() match {
       case JobFailed(_) => println("Job failed, expected.")

--- a/scattersphere-core/src/test/scala/com/scattersphere/core/util/SimpleJobTest.scala
+++ b/scattersphere-core/src/test/scala/com/scattersphere/core/util/SimpleJobTest.scala
@@ -91,7 +91,7 @@ class SimpleJobTest extends FlatSpec with Matchers  {
     runnableTask3.setVar shouldBe 0
 
     job1.getStatus() shouldBe JobQueued
-    jobExec.queue().runBlocking()
+    jobExec.queue().run()
     job1.getStatus() shouldBe JobFinished
 
     runnableTask1.setVar shouldBe 1
@@ -131,7 +131,7 @@ class SimpleJobTest extends FlatSpec with Matchers  {
     val jobExec: JobExecutor = new JobExecutor(job1)
 
     job1.getStatus() shouldBe JobQueued
-    jobExec.queue().runBlocking()
+    jobExec.queue().run()
     job1.getStatus() shouldBe JobFinished
 
     runnableTask1.setVar shouldBe 1
@@ -153,7 +153,7 @@ class SimpleJobTest extends FlatSpec with Matchers  {
     val jobExec: JobExecutor = new JobExecutor(job1)
 
     job1.getStatus() shouldBe JobQueued
-    jobExec.queue().runBlocking()
+    jobExec.queue().run()
     job1.getStatus() shouldBe JobFinished
 
     runnableTask1.setVar shouldBe 1
@@ -164,7 +164,7 @@ class SimpleJobTest extends FlatSpec with Matchers  {
 
     // This will be upgraded soon so that the underlying cause can be pulled from the Job, but only if the job
     // completes exceptionally.
-    jobExec2.queue().runBlocking()
+    jobExec2.queue().run()
     job2.getStatus() match {
       case JobFailed(_) => println("Job failed, expected.")
       case x => fail(s"Unexpected job status: $x")


### PR DESCRIPTION
Cleanup includes work to rename getters to their names, rather than "getX", which follows Java conventions.  No need - this ain't Java.

Added `setBlocking` function instead of `runBlocking` and `runNonblocking` which literally made no sense.  Changed those functions to a single `run`.