### PR TITLE
Clean-up.

### DIFF
--- a/scattersphere-core/src/test/scala/com/scattersphere/core/util/ComplicatedJobTest.scala
+++ b/scattersphere-core/src/test/scala/com/scattersphere/core/util/ComplicatedJobTest.scala
@@ -16,6 +16,7 @@ package com.scattersphere.core.util
 import java.util.concurrent.atomic.AtomicInteger
 
 import com.scattersphere.core.util.execution.JobExecutor
+import com.typesafe.scalalogging.LazyLogging
 import org.scalatest.{FlatSpec, Matchers}
 
 /**
@@ -23,7 +24,7 @@ import org.scalatest.{FlatSpec, Matchers}
   *
   * These tasks are more complicated.
   */
-class ComplicatedJobTest extends FlatSpec with Matchers  {
+class ComplicatedJobTest extends FlatSpec with Matchers with LazyLogging {
 
   class RunnableTestTask(name: String) extends RunnableTask {
     var setVar: String = ""
@@ -35,7 +36,7 @@ class ComplicatedJobTest extends FlatSpec with Matchers  {
       val sleepTime = 100
 
       Thread.sleep(sleepTime)
-      println(s"[$name] Sleep thread completed.")
+      logger.trace(s"[$name] Sleep thread completed.")
 
       setVar = name
     }

--- a/scattersphere-core/src/test/scala/com/scattersphere/core/util/ExceptionJobTest.scala
+++ b/scattersphere-core/src/test/scala/com/scattersphere/core/util/ExceptionJobTest.scala
@@ -3,14 +3,15 @@ package com.scattersphere.core.util
 import java.util.concurrent.CompletionException
 
 import com.scattersphere.core.util.execution.JobExecutor
+import com.typesafe.scalalogging.LazyLogging
 import org.scalatest.{FlatSpec, Matchers}
 
-class ExceptionJobTest extends FlatSpec with Matchers {
+class ExceptionJobTest extends FlatSpec with Matchers with LazyLogging {
 
   class TimerJob(duration: Int) extends RunnableTask {
     override def run(): Unit = {
       Thread.sleep(duration * 1000)
-      println(s"Slept $duration second(s)")
+      logger.trace(s"Slept $duration second(s)")
       throw new NullPointerException
     }
   }

--- a/scattersphere-core/src/test/scala/com/scattersphere/core/util/SimpleJobTest.scala
+++ b/scattersphere-core/src/test/scala/com/scattersphere/core/util/SimpleJobTest.scala
@@ -13,9 +13,8 @@
   */
 package com.scattersphere.core.util
 
-import java.util.concurrent.CompletionException
-
 import com.scattersphere.core.util.execution.{InvalidTaskStateException, JobExecutor}
+import com.typesafe.scalalogging.LazyLogging
 import org.scalatest.{FlatSpec, Matchers}
 
 /**
@@ -26,7 +25,7 @@ import org.scalatest.{FlatSpec, Matchers}
   * tasks that create a large DAG.  This code creates a simple set of DAGs: One that follows one after another, and
   * one that runs multiple tasks asynchronously.
   */
-class SimpleJobTest extends FlatSpec with Matchers  {
+class SimpleJobTest extends FlatSpec with Matchers with LazyLogging {
 
   class RunnableTestTask(name: String) extends RunnableTask {
     var setVar: Int = 0
@@ -35,7 +34,7 @@ class SimpleJobTest extends FlatSpec with Matchers  {
       val sleepTime = 100
 
       Thread.sleep(sleepTime)
-      println(s"[$name] Sleep thread completed.")
+      logger.trace(s"[$name] Sleep thread completed.")
 
       setVar = name.toInt
     }


### PR DESCRIPTION
Fixed logging to use `logger.trace` where `println` was used in tests.