### PR TITLE
Ticket-49

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
         <scala-logging.version>3.9.0</scala-logging.version>
         <slf4j.version>1.7.25</slf4j.version>
         <logback.version>1.2.3</logback.version>
+        <spark.version>2.3.0</spark.version>
 
         <!-- Build Properties -->
         <maven.compiler.plugin.version>3.7.0</maven.compiler.plugin.version>
@@ -130,6 +131,12 @@
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
                 <version>${logback.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.spark</groupId>
+                <artifactId>spark-sql_${scala-binary.version}</artifactId>
+                <version>${spark.version}</version>
             </dependency>
 
             <!-- Project Dependencies -->

--- a/scattersphere-core/pom.xml
+++ b/scattersphere-core/pom.xml
@@ -73,6 +73,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql_${scala-binary.version}</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/scattersphere-core/src/main/scala/com/scattersphere/core/util/spark/SparkCache.scala
+++ b/scattersphere-core/src/main/scala/com/scattersphere/core/util/spark/SparkCache.scala
@@ -33,7 +33,17 @@ object SparkCache {
     * @param key key to assign
     * @param conf [[SparkConf]] object to store
     */
-  def save(key: String, conf: SparkConf): Unit = SPARK_CONF_CACHE.put(key, conf)
+  def save(key: String, conf: SparkConf): Unit = {
+    if (key == null) {
+      throw new NullPointerException("Missing key")
+    }
+
+    if (conf == null) {
+      throw new NullPointerException("Missing SparkConf object.")
+    }
+
+    SPARK_CONF_CACHE.put(key, conf)
+  }
 
   /** Retrieves the [[SparkConf]] by the specified key.
     *

--- a/scattersphere-core/src/main/scala/com/scattersphere/core/util/spark/SparkCache.scala
+++ b/scattersphere-core/src/main/scala/com/scattersphere/core/util/spark/SparkCache.scala
@@ -1,0 +1,52 @@
+/**
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+package com.scattersphere.core.util.spark
+
+import java.util.concurrent.{ConcurrentHashMap, ConcurrentMap}
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.SparkSession
+
+/** Factory convenience object used to store [[SparkConf]] objects by key name, and generate [[SparkSession]]
+  * sessions based on configurations.
+  *
+  * @since 0.2.0
+  */
+object SparkCache {
+
+  private val SPARK_CONF_CACHE: ConcurrentMap[String, SparkConf] = new ConcurrentHashMap()
+
+  /** Saves a [[SparkConf]] by key.
+    *
+    * @param key key to assign
+    * @param conf [[SparkConf]] object to store
+    */
+  def save(key: String, conf: SparkConf): Unit = SPARK_CONF_CACHE.put(key, conf)
+
+  /** Retrieves the [[SparkConf]] by the specified key.
+    *
+    * @param key key to retrieve
+    * @return [[SparkConf]] or null if not found
+    */
+  def getConf(key: String): SparkConf = SPARK_CONF_CACHE.get(key)
+
+  /** Creates a new [[SparkSession]] based on the criteria set in the [[SparkConf]] for the given key.
+    *
+    * @param key key to retrieve
+    * @return [[SparkSession]] that is active for that key, or creates a new one if none exists
+    */
+  def getSession(key: String): SparkSession = SparkSession.builder().config(getConf(key)).getOrCreate()
+
+}

--- a/scattersphere-core/src/test/scala/com/scattersphere/core/util/spark/SparkCacheTest.scala
+++ b/scattersphere-core/src/test/scala/com/scattersphere/core/util/spark/SparkCacheTest.scala
@@ -1,0 +1,55 @@
+/**
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+package com.scattersphere.core.util.spark
+
+import com.typesafe.scalalogging.LazyLogging
+import org.apache.spark.sql.SparkSession
+
+import scala.math.random
+import org.apache.spark.{SparkConf, SparkContext}
+import org.scalatest.{FlatSpec, Matchers}
+
+/** Spark Cache Test code.  Utilizes some code from the SparkPi test from the official Spark source code.
+  * Reference: https://github.com/apache/spark/blob/master/examples/src/main/scala/org/apache/spark/examples/SparkPi.scala
+  *
+  * @since 0.2.0
+  */
+class SparkCacheTest extends FlatSpec with Matchers with LazyLogging {
+
+  "Spark Cache" should "calculate Pi quickly in a local[*] context" in {
+    SparkCache.save("test", new SparkConf()
+      .setMaster("local[*]")
+      .setAppName("local pi test")
+      .set("spark.ui.enabled", "false"))
+    val spark: SparkSession = SparkCache.getSession("test")
+    val sContext: SparkContext = spark.sparkContext
+
+    val slices = 2
+    val n = math.min(100000L * slices, Int.MaxValue).toInt
+    val count = sContext.parallelize(1 until n, slices).map { _ =>
+      val x = random * 2 - 1
+      val y = random * 2 - 1
+
+      if (x * x + y * y <= 1) 1 else 0
+    }.reduce(_ + _)
+
+    val pi = 4.0 * count / (n - 1)
+    
+    assert(pi >= 3.0 && pi <= 3.2)
+
+    spark.stop
+  }
+
+}

--- a/scattersphere-core/src/test/scala/com/scattersphere/core/util/spark/SparkCacheTest.scala
+++ b/scattersphere-core/src/test/scala/com/scattersphere/core/util/spark/SparkCacheTest.scala
@@ -46,10 +46,26 @@ class SparkCacheTest extends FlatSpec with Matchers with LazyLogging {
     }.reduce(_ + _)
 
     val pi = 4.0 * count / (n - 1)
-    
+
     assert(pi >= 3.0 && pi <= 3.2)
 
     spark.stop
+  }
+
+  it should "throw a NullPointerException for a missing key or missing SparkConf" in {
+    assertThrows[NullPointerException] {
+      SparkCache.save(null, new SparkConf())
+    }
+
+    assertThrows[NullPointerException] {
+      SparkCache.save("test1234", null)
+    }
+  }
+
+  it should "throw a NullPointerException for a missing key when creating a SparkSession" in {
+    assertThrows[NullPointerException] {
+      SparkCache.getSession("nonexistent entry")
+    }
   }
 
 }

--- a/scattersphere-tasks/pom.xml
+++ b/scattersphere-tasks/pom.xml
@@ -83,6 +83,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql_${scala-binary.version}</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.suenobu</groupId>
             <artifactId>scattersphere-core</artifactId>
         </dependency>


### PR DESCRIPTION
This adds initial support for Spark Caching by key name.  It allows for a `SparkConf` object to be stored and retrieved by key, as well as a `SparkSession` to be created from said key.